### PR TITLE
Overhaul documentation style and add release notes

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,14 +1,4 @@
-html[data-theme="light"] {
-  --pst-color-primary: rgb(93, 154, 181);
-  --pst-color-secondary: rgb(93, 154, 181);
-  --pst-color-secondary-bg: rgb(223, 235, 240);
-}
-
-html[data-theme="dark"] {
-  --pst-color-primary: rgb(93, 155, 182);
-  --pst-color-secondary: rgb(93, 155, 182);
-  --pst-color-secondary-bg: rgb(33, 45, 51);
-}
+@import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Open+Sans:ital,wght@0,400;0,600;1,400;1,600&display=swap');
 
 .navbar-brand img {
   height: 75px;
@@ -16,11 +6,41 @@ html[data-theme="dark"] {
 
 .navbar-brand {
   height: 75px;
+  flex-shrink: 0;
 }
+
+/* Prevent logo text from overlapping header links and bold the title */
+.navbar-brand .logo__title,
+.navbar-brand-box .logo__title,
+p.logo__title {
+  font-size: 1.1rem;
+  white-space: nowrap;
+  font-weight: bold !important;
+}
+
+/* Bold the main page title */
+h1 {
+  font-weight: bold;
+}
+
+/* Add spacing between logo/title and header navigation links */
+.navbar-header-items {
+  margin-left: 2rem;
+}
+
+body {
+  font-family: 'Open Sans', sans-serif;
+  font-size: medium;
+}
+
+/* Making sure the navbar shows correctly in one line
+   Reduces the space between the top-left logo and the navbar section titles */
 
 .col-lg-3 {
   width: 15%;
 }
+
+/* Version switcher from PyData Sphinx Theme */
 
 .version-switcher__menu a.list-group-item {
   font-size: small;
@@ -32,6 +52,8 @@ button.btn.version-switcher__button:hover {
   font-size: small;
 }
 
+/* Main index page overview cards */
+
 .sd-card .sd-card-img-top {
   height: 60px;
   width: 60px;
@@ -40,9 +62,13 @@ button.btn.version-switcher__button:hover {
   margin-top: 10px;
 }
 
+/* Main index page overview images */
+
 html[data-theme=dark] .sd-card img[src*='.svg'] {
   filter: invert(0.82) brightness(0.8) contrast(1.2);
 }
+
+/* Legacy admonition */
 
 div.admonition-legacy {
   border-color: var(--pst-color-warning);
@@ -55,6 +81,8 @@ div.admonition-legacy>.admonition-title::after {
 div.admonition-legacy>.admonition-title {
   background-color: var(--pst-color-warning-bg);
 }
+
+/* Buttons for JupyterLite-enabled interactive examples */
 
 .try_examples_button {
   color: white;
@@ -69,6 +97,7 @@ div.admonition-legacy>.admonition-title {
   font-size: small;
 }
 
+/* Use more accessible colours for text in dark mode */
 [data-theme=dark] .try_examples_button {
   color: black;
 }
@@ -86,137 +115,8 @@ div.admonition-legacy>.admonition-title {
   margin-bottom: 20px;
 }
 
+/* Better gaps for examples buttons under admonitions */
+
 .try_examples_outer_iframe {
   margin-top: 0.4em;
-}
-
-h1 {
-  word-wrap: break-word;
-}
-
-h1#moderndid-documentation {
-  font-weight: bold;
-}
-
-.bd-container {
-  max-width: 100%;
-}
-
-.bd-header .bd-header__inner {
-  max-width: 1400px;
-  margin: 0 auto;
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
-
-.bd-content .bd-article-container {
-  max-width: 1400px;
-  margin: 0 auto;
-}
-
-div.empty + section>h1 {
-  font-family: var(--pst-font-family-monospace);
-}
-
-.prename {
-  font-family: var(--pst-font-family-monospace);
-  font-size: var(--pst-font-size-h4);
-}
-
-.sig-prename {
-  display: none;
-}
-
-.bd-header-nav-items {
-  margin-left: 1rem;
-}
-
-ul.bd-navbar-elements {
-  padding-left: 1rem;
-}
-
-.navbar-nav {
-  margin-left: 1rem;
-}
-
-.wy-nav-side p.caption {
-  color: #F5F5F5;
-}
-
-div.wy-side-nav-search {
-  background: #757575;
-}
-
-div.wy-side-nay {
-  background: #212121;
-}
-
-table.field-list td li {
-  line-height: 18px;
-}
-
-table.docutils td p {
-  font-size: 14px !important;
-  margin-bottom: 6px;
-}
-
-table.docutils td li {
-  line-height: 18px;
-}
-
-table td.vl-type-def {
-  max-width: 170px;
-  overflow-x: clip;
-}
-
-#rtd-footer-container {
-  display: none;
-}
-
-.bd-sidebar-primary {
-  max-width: 20%
-}
-
-@media (max-width: 959.98px) {
-  .bd-sidebar-primary {
-      max-width: 350px;
-  }
-}
-
-.properties-example .vega-bind-name {
-  display: inline-block;
-  min-width: 150px;
-}
-
-.properties-example .vega-bindings {
-  padding-left: 20px;
-  padding-bottom: 10px;
-}
-
-.properties-example .vega-bindings select {
-  max-width: 180px;
-}
-
-.properties-example .vega-bindings input {
-  vertical-align: text-bottom;
-  margin-right: 3px;
-}
-
-.full-width-plot {
-  width: 100%;
-}
-
-.search-button-field > .search-button__kbd-shortcut {
-    display: none;
-}
-
-.lead {
-  font-size: 1.3em;
-  font-weight: 300;
-  margin-top: 22px;
-  margin-bottom: 22px;
-}
-
-.lead strong {
-  font-weight: bold;
 }

--- a/docs/source/api/drdid.rst
+++ b/docs/source/api/drdid.rst
@@ -1,7 +1,7 @@
 .. _api-drdid:
 
-Doubly Robust DiD Estimators
-============================
+Doubly Robust DiD
+=================
 
 The drdid module provides all two-period difference-in-differences estimators,
 including doubly robust, inverse propensity weighted, and outcome regression methods.

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -2,31 +2,35 @@
 
 .. _api:
 
-##############
+#############
 API Reference
-##############
+#############
 
 :Release: |version|
 :Date: |today|
 
-This is the comprehensive API reference for **ModernDiD**, covering all public functions
-and classes available in the package. The documentation is generated automatically from
-the code documentation strings. Please refer to the :ref:`background` section for
-theoretical explanations and the :ref:`example_gallery` section for practical examples.
+This is the API reference for ModernDiD; details on the underlying
+methodology are found in :ref:`background`.
 
 .. toctree::
+   :caption: Core estimators
    :maxdepth: 2
-   :caption: API Modules
 
    multiperiod
    drdid
-   honestdid
+
+.. toctree::
+   :caption: Extensions
+   :maxdepth: 2
+
    didcont
    didtriple
+   honestdid
+
+.. toctree::
+   :caption: Utilities
+   :maxdepth: 2
+
    propensity
    bootstrap
    plotting
-
-.. note::
-   The API is stable for all documented functions. Additional modules under development
-   will be added in future releases.

--- a/docs/source/background/index.rst
+++ b/docs/source/background/index.rst
@@ -4,17 +4,13 @@
 Background
 ##########
 
-:Release: |version|
-:Date: |today|
-
-The following pages provide theoretical background and detailed explanations of the
-difference-in-differences methodologies implemented in **ModernDiD**, including
-the econometric theory, identification assumptions, and estimation approaches
-for each method.
+This section provides theoretical background on the difference-in-differences
+methodologies implemented in ModernDiD; for practical usage see the
+:ref:`User Guide <user-guide>`.
 
 .. toctree::
+   :caption: Methodology
    :maxdepth: 2
-   :caption: Contents
 
    did
    drdid

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -141,12 +141,12 @@ html_theme_options = {
         "image_light": "_static/logo.svg",
         "image_dark": "_static/logo.svg",
     },
-    "collapse_navigation": True,
+    "collapse_navigation": False,
     "navbar_start": ["navbar-logo"],
     "navbar_end": ["search-button", "theme-switcher", "navbar-icon-links"],
     "navbar_persistent": [],
-    "secondary_sidebar_items": ["page-toc"],
     "show_version_warning_banner": False,
+    "navigation_depth": 4,
 }
 
 html_title = f"{project} v{version} Manual"

--- a/docs/source/dev/contributing.rst
+++ b/docs/source/dev/contributing.rst
@@ -148,12 +148,3 @@ To build and preview the documentation locally::
 
 The built documentation will be available in ``.tox/docs/docs_out/``. Open
 ``index.html`` in a browser to review your changes before submitting.
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Development
-   :hidden:
-
-   self
-   architecture
-   testing

--- a/docs/source/dev/index.rst
+++ b/docs/source/dev/index.rst
@@ -1,0 +1,21 @@
+.. _development:
+
+###########
+Development
+###########
+
+This section covers how to contribute to ModernDiD and understand its
+internals; for usage documentation see the :ref:`User Guide <user-guide>`.
+
+.. toctree::
+   :caption: Contributing
+   :maxdepth: 2
+
+   contributing
+   testing
+
+.. toctree::
+   :caption: Internals
+   :maxdepth: 2
+
+   architecture

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,61 +1,109 @@
-:html_theme.sidebar_secondary.remove:
+.. _moderndid_docs_mainpage:
 
-ModernDiD: Modern Difference-in-Differences in Python
-======================================================
-
-.. role:: raw-html(raw)
-   :format: html
-
-.. rst-class:: lead
-
-   **ModernDiD** is a unified Python implementation of modern difference-in-differences (DiD) methodologies built on leading econometric research. It brings together the fragmented landscape of DiD estimators into a single, coherent framework with a consistent and intuitive API.
-
-.. warning::
-
-   This package is currently in active development and the API is subject to change.
-
-
-.. grid:: 1 1 2 2
-   :padding: 0 2 3 5
-   :gutter: 2 2 3 3
-   :class-container: startpage-grid
-
-   .. grid-item-card:: Getting Started
-      :link: overview
-      :link-type: ref
-      :link-alt: Getting started
-
-      Find installation instructions and learn about the core concepts of difference-in-differences methodology.
-
-   .. grid-item-card:: User Guide
-      :link: user-guide
-      :link-type: ref
-      :link-alt: User guide
-
-      Check out the User Guide for in-depth information on implementing DiD estimators and understanding the underlying econometrics.
-
-   .. grid-item-card:: Examples
-      :link: examples/index
-      :link-type: doc
-      :link-alt: Examples
-
-      The Examples gallery contains practical demonstrations of different DiD estimators with real-world data scenarios.
-
-   .. grid-item-card:: API Reference
-      :link: api/index
-      :link-type: doc
-      :link-alt: API
-
-      The API reference guide contains detailed information on all of moderndid's estimators, methods, and classes.
-
+#########################
+ModernDiD documentation
+#########################
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :hidden:
 
    Getting Started <getting_started/overview>
-   User Guide <user_guide/user_guide>
+   User Guide <user_guide/index>
    API <api/index>
-   Development <dev/contributing>
+   Development <dev/index>
    Background <background/index>
    Release Notes <release/index>
+
+
+**Version**: |version|
+
+**Useful links**:
+`Installation <getting_started/installation.html>`_ |
+`Source Repository <https://github.com/jordandeklerk/moderndid>`_ |
+`Issue Tracker <https://github.com/jordandeklerk/moderndid/issues>`_ |
+`PyPI <https://pypi.org/project/moderndid/>`_
+
+ModernDiD is a unified Python implementation of modern difference-in-differences
+(DiD) methodologies built on leading econometric research. It brings together
+the fragmented landscape of DiD estimators into a single, coherent framework
+with a consistent and intuitive API.
+
+.. grid:: 1 1 2 2
+    :gutter: 2 3 4 4
+
+    .. grid-item-card::
+        :img-top: _static/tutorial.svg
+        :text-align: center
+
+        Getting started
+        ^^^
+
+        New to ModernDiD? Check out the Getting Started guide for installation
+        instructions and an introduction to difference-in-differences methodology.
+
+        +++
+
+        .. button-ref:: overview
+            :expand:
+            :color: secondary
+            :click-parent:
+
+            To the getting started guide
+
+    .. grid-item-card::
+        :img-top: _static/user_guide.svg
+        :text-align: center
+
+        User guide
+        ^^^
+
+        The user guide provides in-depth tutorials and practical guidance for
+        implementing DiD estimators with real-world data scenarios.
+
+        +++
+
+        .. button-ref:: user-guide
+            :expand:
+            :color: secondary
+            :click-parent:
+
+            To the user guide
+
+    .. grid-item-card::
+        :img-top: _static/api_reference.svg
+        :text-align: center
+
+        API reference
+        ^^^
+
+        The API reference contains detailed documentation on all of ModernDiD's
+        estimators, methods, and classes including function signatures and parameters.
+
+        +++
+
+        .. button-ref:: api
+            :expand:
+            :color: secondary
+            :click-parent:
+
+            To the API reference
+
+    .. grid-item-card::
+        :img-top: _static/developer.svg
+        :text-align: center
+
+        Development
+        ^^^
+
+        Want to contribute to ModernDiD? The development guide covers setup,
+        coding standards, testing, and submission guidelines.
+
+        +++
+
+        .. button-ref:: development
+            :expand:
+            :color: secondary
+            :click-parent:
+
+            To the development guide

--- a/docs/source/release/0.0.1-notes.rst
+++ b/docs/source/release/0.0.1-notes.rst
@@ -1,0 +1,188 @@
+.. currentmodule:: moderndid
+
+=============================
+ModernDiD 0.0.1 Release Notes
+=============================
+
+ModernDiD 0.0.1 is the initial release of the package, providing a unified
+Python implementation of modern difference-in-differences methodologies.
+
+Highlights
+==========
+
+This release includes the core functionality for difference-in-differences
+estimation:
+
+- **Multi-period staggered DiD**: Implementation of the `Callaway and Sant'Anna
+  (2021) <https://doi.org/10.1016/j.jeconom.2020.12.001>`__ estimator for staggered
+  treatment adoption designs via ``att_gt()`` and ``aggte()`` functions
+- **Doubly robust DiD estimators**: Full suite of DR-DiD estimators for both
+  panel data and repeated cross-sections following `Sant'Anna and Zhao (2020)
+  <https://doi.org/10.1016/j.jeconom.2020.06.003>`__
+- **Sensitivity analysis**: HonestDiD module implementing `Rambachan and Roth
+  (2023) <https://doi.org/10.1093/restud/rdad018>`__ sensitivity analysis for
+  parallel trends violations
+- **Bootstrap inference**: Multiplier bootstrap for standard errors and
+  simultaneous confidence bands
+
+New Features
+============
+
+Core Estimators
+---------------
+
+- Add ``att_gt()`` function for group-time average treatment effects
+- Add ``aggte()`` function for aggregating group-time effects into event
+  studies, overall ATT, group effects, and calendar time effects
+- Add doubly robust DiD estimators (``drdid_panel``, ``drdid_rc``)
+- Add IPW and outcome regression DiD estimators
+- Add two-way fixed effects estimators
+
+Sensitivity Analysis
+--------------------
+
+- Add HonestDiD sensitivity analysis functions following `Rambachan and Roth (2023)
+  <https://doi.org/10.1093/restud/rdad018>`__
+- Support for smoothness restrictions and relative magnitudes bounds
+- Add ARP confidence interval functions
+
+Infrastructure
+--------------
+
+- Add ``load_mpdta()`` function for loading example minimum wage dataset
+- Add comprehensive documentation with Sphinx
+- Add test suite with pytest
+- Set up CI/CD with GitHub Actions
+
+
+Major Commits
+=============
+
+.. note::
+
+   This project began as a solo side project, and at the time I did not anticipate
+   it growing into a full software package. As a result, the initial development
+   did not follow best practices such as using pull requests for changes. Starting
+   with version 0.0.2, all changes are tracked via pull requests.
+
+A total of 450 commits were made for this release, including 102 feature commits,
+24 bug fixes, and 98 refactors. Below are 70 key commits grouped by area
+(excluding documentation, chore, and automated updates).
+
+Core Estimators
+---------------
+
+* `415d74c <https://github.com/jordandeklerk/moderndid/commit/415d74c>`__: Add DR-DiD wrapper for doubly robust DiD estimators
+* `1fc3981 <https://github.com/jordandeklerk/moderndid/commit/1fc3981>`__: Add ``drdid_panel`` estimator
+* `06b77e9 <https://github.com/jordandeklerk/moderndid/commit/06b77e9>`__: Add DR-DiD estimators for improved and locally efficient repeated cross-section
+* `371e886 <https://github.com/jordandeklerk/moderndid/commit/371e886>`__: Add DR-DiD estimator for panel data and fix IPT propensity computation
+* `0f29f03 <https://github.com/jordandeklerk/moderndid/commit/0f29f03>`__: Add inverse-propensity weighted DiD estimator
+* `91e092c <https://github.com/jordandeklerk/moderndid/commit/91e092c>`__: Add IPW DiD estimator for panel data
+* `5d8b8d2 <https://github.com/jordandeklerk/moderndid/commit/5d8b8d2>`__: Add standardized IPW DiD estimator for repeated cross-section
+* `f7ed590 <https://github.com/jordandeklerk/moderndid/commit/f7ed590>`__: Add standardized IPW estimator for panel data
+* `27e2f03 <https://github.com/jordandeklerk/moderndid/commit/27e2f03>`__: Add outcome regression DiD estimator
+* `29f5144 <https://github.com/jordandeklerk/moderndid/commit/29f5144>`__: Add outcome regression panel DiD estimator
+* `2a23230 <https://github.com/jordandeklerk/moderndid/commit/2a23230>`__: Add ``drdid_trad_rc`` estimator
+* `31ac269 <https://github.com/jordandeklerk/moderndid/commit/31ac269>`__: Add DR-DiD locally efficient estimator
+* `b21d6b0 <https://github.com/jordandeklerk/moderndid/commit/b21d6b0>`__: Add IPW wrapper
+* `0a107b7 <https://github.com/jordandeklerk/moderndid/commit/0a107b7>`__: Add TWFE DiD estimators
+* `afc3187 <https://github.com/jordandeklerk/moderndid/commit/afc3187>`__: Add WOLS estimators
+
+Multi-period Staggered DiD
+--------------------------
+
+* `9bcb04a <https://github.com/jordandeklerk/moderndid/commit/9bcb04a>`__: Add ``att_gt`` function
+* `74d84bc <https://github.com/jordandeklerk/moderndid/commit/74d84bc>`__: Add wrapper for aggregate ATT
+* `c77b572 <https://github.com/jordandeklerk/moderndid/commit/c77b572>`__: Add ``compute_aggte`` function with group assignments and sampling weights
+* `42ca5ae <https://github.com/jordandeklerk/moderndid/commit/42ca5ae>`__: Add ``compute_att_gt`` functions for multi-period DiD analysis
+* `05d012b <https://github.com/jordandeklerk/moderndid/commit/05d012b>`__: Add multi-period and aggregate treatment effect result objects
+* `40455b7 <https://github.com/jordandeklerk/moderndid/commit/40455b7>`__: Add influence function support for overall ATT in AGGTE results
+* `b2643d3 <https://github.com/jordandeklerk/moderndid/commit/b2643d3>`__: Add ``MPPretestResult`` for pre-test of parallel trends assumption
+
+HonestDiD Sensitivity Analysis
+------------------------------
+
+* `852de48 <https://github.com/jordandeklerk/moderndid/commit/852de48>`__: Add new directory for Honest DiD
+* `53fe33b <https://github.com/jordandeklerk/moderndid/commit/53fe33b>`__: Add utility functions for Honest DiD analysis
+* `4aad9b1 <https://github.com/jordandeklerk/moderndid/commit/4aad9b1>`__: Add APR confidence interval functions
+* `aff332f <https://github.com/jordandeklerk/moderndid/commit/aff332f>`__: Add ARP confidence interval functions with nuisance params
+* `bc4f165 <https://github.com/jordandeklerk/moderndid/commit/bc4f165>`__: Add functions for fixed-length confidence intervals (FLCI)
+* `4ff564a <https://github.com/jordandeklerk/moderndid/commit/4ff564a>`__: Add functions for bound estimation and conditional tests
+* `1e628c4 <https://github.com/jordandeklerk/moderndid/commit/1e628c4>`__: Add functions for relative magnitudes restrictions
+* `700dfff <https://github.com/jordandeklerk/moderndid/commit/700dfff>`__: Add monotonicity and sign constraint matrix functions
+* `a8a479a <https://github.com/jordandeklerk/moderndid/commit/a8a479a>`__: Add functions for second difference inference
+* `f043407 <https://github.com/jordandeklerk/moderndid/commit/f043407>`__: Add Honest DiD main sensitivity analysis functions
+* `846b5f9 <https://github.com/jordandeklerk/moderndid/commit/846b5f9>`__: Add sensitivity analysis and plotting functions
+
+Bootstrap Inference
+-------------------
+
+* `3918479 <https://github.com/jordandeklerk/moderndid/commit/3918479>`__: Add ``mboot`` function
+* `1def724 <https://github.com/jordandeklerk/moderndid/commit/1def724>`__: Add standard multiplier bootstrap functionality
+* `0c817c0 <https://github.com/jordandeklerk/moderndid/commit/0c817c0>`__: Add ``mboot_twfep_did`` function for TWFE bootstrap
+* `a1f0be2 <https://github.com/jordandeklerk/moderndid/commit/a1f0be2>`__: Add bootstrap inference for doubly-robust DiD estimators
+* `de30695 <https://github.com/jordandeklerk/moderndid/commit/de30695>`__: Add IPT bootstrap functions
+* `4276f80 <https://github.com/jordandeklerk/moderndid/commit/4276f80>`__: Add traditional bootstrap for DR-DiD with panel data
+* `d3ca89e <https://github.com/jordandeklerk/moderndid/commit/d3ca89e>`__: Add improved bootstrap for DR-DiD with panel data
+* `f57828d <https://github.com/jordandeklerk/moderndid/commit/f57828d>`__: Add ``wboot_drdid_rc`` for DR-DiD bootstrap with repeated cross-section
+* `fedcea8 <https://github.com/jordandeklerk/moderndid/commit/fedcea8>`__: Add ``wboot_twfe_rc`` estimator
+* `57c5b50 <https://github.com/jordandeklerk/moderndid/commit/57c5b50>`__: Add ``wboot_std_ipw_rc`` estimator
+* `14c096c <https://github.com/jordandeklerk/moderndid/commit/14c096c>`__: Add ``wboot_reg_rc`` estimator
+
+Data and Preprocessing
+----------------------
+
+* `8d340e0 <https://github.com/jordandeklerk/moderndid/commit/8d340e0>`__: Add ``load_mpdta`` function for multiple time period DiD analysis
+* `6b7d2b1 <https://github.com/jordandeklerk/moderndid/commit/6b7d2b1>`__: Add preprocessing functions
+* `a3101fa <https://github.com/jordandeklerk/moderndid/commit/a3101fa>`__: Add DR-DiD preprocessing module
+* `d4b1862 <https://github.com/jordandeklerk/moderndid/commit/d4b1862>`__: Add panel and RC utility functions
+* `10a0ede <https://github.com/jordandeklerk/moderndid/commit/10a0ede>`__: Add print function for DiD results
+
+Propensity Score
+----------------
+
+* `ab7a1ff <https://github.com/jordandeklerk/moderndid/commit/ab7a1ff>`__: Add propensity score methods
+* `48e3b06 <https://github.com/jordandeklerk/moderndid/commit/48e3b06>`__: Add trimming functionality to AIPW estimators
+* `ab084c1 <https://github.com/jordandeklerk/moderndid/commit/ab084c1>`__: Enhance IPT propensity score with quantile constraints and collinearity removal
+
+Bug Fixes
+---------
+
+* `fb18373 <https://github.com/jordandeklerk/moderndid/commit/fb18373>`__: Fix grid bounds issues and computations
+* `74cd52c <https://github.com/jordandeklerk/moderndid/commit/74cd52c>`__: Fix trapezoidal integration for CI length and linear program solver
+* `c51ff0b <https://github.com/jordandeklerk/moderndid/commit/c51ff0b>`__: Fix pre-period constraint matrix calculations
+* `e7b32b4 <https://github.com/jordandeklerk/moderndid/commit/e7b32b4>`__: Update IPW estimator to use original weights directly
+* `e0fe502 <https://github.com/jordandeklerk/moderndid/commit/e0fe502>`__: Improve error handling and warnings in weighted OLS functions
+
+Performance and Refactoring
+---------------------------
+
+* `ed7acbf <https://github.com/jordandeklerk/moderndid/commit/ed7acbf>`__: Integrate Numba for performance optimization
+* `202dc12 <https://github.com/jordandeklerk/moderndid/commit/202dc12>`__: Move second difference and monotonicity matrix implementations to Numba
+* `d9b815f <https://github.com/jordandeklerk/moderndid/commit/d9b815f>`__: Replace custom functions with optimized Numba versions
+* `e7ef260 <https://github.com/jordandeklerk/moderndid/commit/e7ef260>`__: Improve grid default bound calculations in RM and SDRM functions
+* `d347dd3 <https://github.com/jordandeklerk/moderndid/commit/d347dd3>`__: Enhance grid bounds calculation using identified sets
+* `3966275 <https://github.com/jordandeklerk/moderndid/commit/3966275>`__: Enhance modularity and clarity in DiD estimators
+
+Infrastructure
+--------------
+
+* `e46bc8f <https://github.com/jordandeklerk/moderndid/commit/e46bc8f>`__: Initial repo setup
+* `dbed5b8 <https://github.com/jordandeklerk/moderndid/commit/dbed5b8>`__: Add CodeQL workflow
+
+Testing
+-------
+
+* `585bdbd <https://github.com/jordandeklerk/moderndid/commit/585bdbd>`__: Add tests for AIPW estimators and preprocess functions
+* `a564175 <https://github.com/jordandeklerk/moderndid/commit/a564175>`__: Add tests for DR-DiD DGP
+* `127ce5d <https://github.com/jordandeklerk/moderndid/commit/127ce5d>`__: Add ARP nuisance parameter tests
+* `9aa1d07 <https://github.com/jordandeklerk/moderndid/commit/9aa1d07>`__: Add tests for preprocessing
+* `c854616 <https://github.com/jordandeklerk/moderndid/commit/c854616>`__: Add tests for ``wboot_ipw_panel``
+
+
+Contributors
+============
+
+A total of 1 person contributed to this release.
+
+* Jordan Deklerk

--- a/docs/source/release/0.0.2-notes.rst
+++ b/docs/source/release/0.0.2-notes.rst
@@ -1,0 +1,124 @@
+.. currentmodule:: moderndid
+
+=============================
+ModernDiD 0.0.2 Release Notes
+=============================
+
+ModernDiD 0.0.2 is a major feature release that adds triple difference-in-differences
+estimation, continuous treatment DiD, migrates from pandas to polars for improved
+performance, and integrates plotnine for publication-quality visualizations.
+
+Highlights
+==========
+
+- **Triple Difference-in-Differences**: New ``ddd()`` estimator for designs with
+  an additional dimension of variation (e.g., eligibility status)
+- **Continuous Treatment DiD**: New ``cont_did()`` function for settings with
+  treatment intensity rather than binary treatment
+- **Polars migration**: Migrated from pandas to polars for faster DataFrame operations
+- **Plotnine integration**: New plotting functions using plotnine for
+  publication-quality visualizations
+- **Unified API**: Consistent argument names across all main estimators
+
+New Features
+============
+
+Triple Difference-in-Differences
+--------------------------------
+
+- Add ``ddd()`` function for triple DiD estimation with panel data
+- Add ``agg_ddd()`` function for aggregating triple DiD effects
+- Support for repeated cross-section data in DDD estimators
+- Add DDD-specific plotting functions
+
+Continuous Treatment DiD
+------------------------
+
+- Add ``cont_did()`` function implementing `Callaway, Goodman-Bacon, and
+  Sant'Anna (2024) <https://arxiv.org/abs/2107.02637>`__ for continuous/multi-valued
+  treatments
+- Support for parametric and CCK estimation methods
+- Add dose-response aggregation options
+
+Plotting
+--------
+
+- Integrate plotnine for all visualization functions
+- Add ``plot_gt()`` for group-time effects visualization
+- Add ``plot_event_study()`` for event study plots
+- Add enhanced themes and styling options
+
+Performance Improvements
+------------------------
+
+- Migrate from pandas to polars for DataFrame handling across the codebase
+- Add Numba JIT compilation for computationally intensive operations
+- Optimize weight influence computations
+
+API Changes
+-----------
+
+- Unify argument names across main estimators for consistency
+- Update results formatting for ``aggte()`` and ``agg_ddd()`` functions
+- Add ``random_state`` parameter for bootstrap reproducibility
+
+Bug Fixes
+=========
+
+- Fix plotting functions to use polars DataFrame directly
+- Fix deprecated pandas SettingWithCopyWarning filter
+- Update analytical standard errors in DR-DiD estimators
+- Fix various test suite issues and improve tolerances
+
+
+Contributors
+============
+
+A total of 1 person contributed to this release.
+
+* Jordan Deklerk
+
+
+Pull Requests Merged
+====================
+
+A total of 70 pull requests were merged for this release, of which 37 are
+feature or fix PRs (excluding automated dependency updates).
+
+* `#114 <https://github.com/jordandeklerk/moderndid/pull/114>`__: Unify main function arguments
+* `#113 <https://github.com/jordandeklerk/moderndid/pull/113>`__: Integrate plotnine for all plotting
+* `#111 <https://github.com/jordandeklerk/moderndid/pull/111>`__: Migrate codebase from pandas to polars
+* `#110 <https://github.com/jordandeklerk/moderndid/pull/110>`__: Update testing instructions for Tox usage
+* `#109 <https://github.com/jordandeklerk/moderndid/pull/109>`__: Add tighter tolerances for point estimates in R tests
+* `#108 <https://github.com/jordandeklerk/moderndid/pull/108>`__: Add the ``didtriple`` readme
+* `#106 <https://github.com/jordandeklerk/moderndid/pull/106>`__: Update test instructions in contributing guide
+* `#105 <https://github.com/jordandeklerk/moderndid/pull/105>`__: Add multi-period repeated cross section DDD functionality
+* `#103 <https://github.com/jordandeklerk/moderndid/pull/103>`__: Add unified DDD estimator and numba optimizations
+* `#102 <https://github.com/jordandeklerk/moderndid/pull/102>`__: Add aggregated treatment effects for triple DiD
+* `#101 <https://github.com/jordandeklerk/moderndid/pull/101>`__: Add multi-period DDD estimator
+* `#100 <https://github.com/jordandeklerk/moderndid/pull/100>`__: Add 2 period panel DDD estimator
+* `#98 <https://github.com/jordandeklerk/moderndid/pull/98>`__: Add nuisance function estimation for DDD
+* `#97 <https://github.com/jordandeklerk/moderndid/pull/97>`__: Add 2-period triple DiD preprocessing logic
+* `#96 <https://github.com/jordandeklerk/moderndid/pull/96>`__: Add ``random_state`` for bootstrap reproducibility
+* `#94 <https://github.com/jordandeklerk/moderndid/pull/94>`__: Add continuous DiD preprocessing functions
+* `#88 <https://github.com/jordandeklerk/moderndid/pull/88>`__: Fix package dependencies
+* `#87 <https://github.com/jordandeklerk/moderndid/pull/87>`__: Add batteries-included plotting via ``PlotCollection`` object
+* `#78 <https://github.com/jordandeklerk/moderndid/pull/78>`__: Unify preprocessing logic for all estimators
+* `#74 <https://github.com/jordandeklerk/moderndid/pull/74>`__: Refactor tox testing environments
+* `#73 <https://github.com/jordandeklerk/moderndid/pull/73>`__: Fix propensity trimming in estimators
+* `#62 <https://github.com/jordandeklerk/moderndid/pull/62>`__: Update analytical standard errors for estimators
+* `#56 <https://github.com/jordandeklerk/moderndid/pull/56>`__: Optimize full test suite for speed
+* `#53 <https://github.com/jordandeklerk/moderndid/pull/53>`__: Update API links
+* `#52 <https://github.com/jordandeklerk/moderndid/pull/52>`__: Add docs for ``didcont``
+* `#51 <https://github.com/jordandeklerk/moderndid/pull/51>`__: Add ``cont_did()`` plotting functions
+* `#42 <https://github.com/jordandeklerk/moderndid/pull/42>`__: Add new docs
+* `#41 <https://github.com/jordandeklerk/moderndid/pull/41>`__: Add main continuous DiD function and preprocessing functions
+* `#37 <https://github.com/jordandeklerk/moderndid/pull/37>`__: Add more processing functions for continuous DiD
+* `#36 <https://github.com/jordandeklerk/moderndid/pull/36>`__: Add splines and panel processing functions
+* `#33 <https://github.com/jordandeklerk/moderndid/pull/33>`__: Fix references in NPIV functions
+* `#32 <https://github.com/jordandeklerk/moderndid/pull/32>`__: Nonparametric IV functions for sieve dimension and UCB estimation
+* `#29 <https://github.com/jordandeklerk/moderndid/pull/29>`__: API doc fix for build
+* `#28 <https://github.com/jordandeklerk/moderndid/pull/28>`__: Update index and API documentation
+* `#27 <https://github.com/jordandeklerk/moderndid/pull/27>`__: Fix layout for headers
+* `#26 <https://github.com/jordandeklerk/moderndid/pull/26>`__: Fix readthedocs error
+* `#25 <https://github.com/jordandeklerk/moderndid/pull/25>`__: Add new logos

--- a/docs/source/release/0.0.3-notes.rst
+++ b/docs/source/release/0.0.3-notes.rst
@@ -1,0 +1,31 @@
+.. currentmodule:: moderndid
+
+=============================
+ModernDiD 0.0.3 Release Notes
+=============================
+
+ModernDiD 0.0.3 is a patch release with minor fixes for PyPI distribution.
+
+Highlights
+==========
+
+- Fix absolute URLs for README images on PyPI
+- Update changelog and release workflow permissions
+
+Pull Requests Merged
+====================
+
+A total of 3 pull requests were merged for this release (all feature or fix PRs,
+no automated dependency updates).
+
+* `#118 <https://github.com/jordandeklerk/moderndid/pull/118>`__: Update changelog for v0.0.2
+* `#117 <https://github.com/jordandeklerk/moderndid/pull/117>`__: Add permissions for post-release workflow
+* `#116 <https://github.com/jordandeklerk/moderndid/pull/116>`__: Bump version to 0.0.2
+
+
+Contributors
+============
+
+A total of 1 person contributed to this release.
+
+* Jordan Deklerk

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -1,9 +1,15 @@
+.. _release-notes:
+
 =============
 Release Notes
 =============
 
-.. note::
-   Release notes will be added as releases are made.
+This page contains release notes for ModernDiD releases.
 
 .. toctree::
    :maxdepth: 1
+
+   unreleased-notes
+   0.0.3-notes
+   0.0.2-notes
+   0.0.1-notes

--- a/docs/source/release/unreleased-notes.rst
+++ b/docs/source/release/unreleased-notes.rst
@@ -1,0 +1,104 @@
+.. currentmodule:: moderndid
+
+=====================
+ModernDiD Unreleased
+=====================
+
+:Date: |today|
+
+This section documents changes that have been merged since the last release
+and will be included in the next version.
+
+Highlights
+==========
+
+- **Bug fixes**: Fixed group aggregation bug and issues in ``cont_did()`` and
+  ``honestdid`` modules
+- **R validation tests**: Added comprehensive validation tests against R packages
+  to ensure numerical accuracy
+- **Enhanced documentation**: Major documentation overhaul including new quickstart
+  guide and improved API documentation
+- **Better error handling**: Added propensity score trimming and collinearity checks
+  with informative error messages
+
+Bug Fixes
+=========
+
+- Fix group aggregation bug in ``aggte()`` function
+- Fix bugs in ``cont_did()`` continuous treatment estimator
+- Fix bugs in ``honestdid`` sensitivity analysis module
+- Fix base period parameter handling
+
+Improvements
+============
+
+Testing
+-------
+
+- Add comprehensive R validation tests for ``att_gt()`` and ``aggte()``
+- Add R validation tests for DR-DiD estimators
+- Add R validation tests for HonestDiD sensitivity analysis
+- Simplify base period parameter and remove unused tests
+- Improve test organization and coverage
+
+Documentation
+-------------
+
+- Add new quickstart guide with practical examples
+- Revise getting started overview
+- Enhance main function docstrings and result output
+- Add repeated cross-section examples for ``ddd()``
+- Improve API documentation for HonestDiD module
+- Add plotting code examples to documentation
+- Extend development docs to include project architecture
+
+Error Handling
+--------------
+
+- Add propensity score trimming functionality
+- Add collinearity checks for covariates
+- Improve error messages with more informative diagnostics
+- Add ``random_state`` parameter for reproducibility in bootstrap
+
+Refactoring
+-----------
+
+- Update random number generation for consistency
+- Update parameter names in documentation
+- Remove unused functions from ``cont_did`` module
+- Remove redundant DGP code
+
+
+Contributors
+============
+
+A total of 1 person contributed to these changes.
+
+* Jordan Deklerk
+
+
+Pull Requests Merged
+====================
+
+A total of 20 pull requests have been merged since v0.0.3, of which 19 are
+feature or fix PRs (excluding automated dependency updates).
+
+* `#138 <https://github.com/jordandeklerk/moderndid/pull/138>`__: Add implementation standards and intro to DiD section to docs
+* `#137 <https://github.com/jordandeklerk/moderndid/pull/137>`__: Reorganize development docs
+* `#136 <https://github.com/jordandeklerk/moderndid/pull/136>`__: Add more detail to the development docs
+* `#135 <https://github.com/jordandeklerk/moderndid/pull/135>`__: Fix computations in ``didhonest`` and add more R validation
+* `#134 <https://github.com/jordandeklerk/moderndid/pull/134>`__: Fix group aggregation in ``aggte()`` and add more R validation
+* `#133 <https://github.com/jordandeklerk/moderndid/pull/133>`__: Add more R validation for ``drdid`` module
+* `#132 <https://github.com/jordandeklerk/moderndid/pull/132>`__: Fix bugs in ``cont_did()`` and add more R validation
+* `#130 <https://github.com/jordandeklerk/moderndid/pull/130>`__: Update getting started docs and test suite
+* `#129 <https://github.com/jordandeklerk/moderndid/pull/129>`__: Add repeated cross-section examples for ``ddd()``
+* `#128 <https://github.com/jordandeklerk/moderndid/pull/128>`__: Improve test coverage
+* `#127 <https://github.com/jordandeklerk/moderndid/pull/127>`__: Update parameter names for ``drdid()``
+* `#126 <https://github.com/jordandeklerk/moderndid/pull/126>`__: Add random state for ``cont_did()``
+* `#125 <https://github.com/jordandeklerk/moderndid/pull/125>`__: Add propensity trimming and collinearity checks for DDD
+* `#124 <https://github.com/jordandeklerk/moderndid/pull/124>`__: Clean up docs for ``HonestDiD``
+* `#123 <https://github.com/jordandeklerk/moderndid/pull/123>`__: Add DDD plotting functions
+* `#122 <https://github.com/jordandeklerk/moderndid/pull/122>`__: Add new DDD tests for coverage
+* `#121 <https://github.com/jordandeklerk/moderndid/pull/121>`__: Rework main function docstrings
+* `#120 <https://github.com/jordandeklerk/moderndid/pull/120>`__: Update docs for ``agg_ddd()`` function
+* `#119 <https://github.com/jordandeklerk/moderndid/pull/119>`__: Update changelog for v0.0.3

--- a/docs/source/user_guide/example_staggered_did.rst
+++ b/docs/source/user_guide/example_staggered_did.rst
@@ -23,7 +23,7 @@ background, see the :ref:`Introduction to Difference-in-Differences <causal_infe
 
 
 Loading data
-============
+------------
 
 .. code-block:: python
 
@@ -58,7 +58,7 @@ interpretation and improves precision.
 
 
 Estimating group-time effects
-=============================
+-----------------------------
 
 The first step is to estimate treatment effects separately for each cohort
 at each time period. This avoids the negative weighting problem that can
@@ -125,7 +125,7 @@ to observe.
 
 
 Aggregating into an event study
-===============================
+-------------------------------
 
 With 12 group-time estimates, the results are difficult to summarize. The
 event study aggregation aligns all cohorts relative to their treatment date,
@@ -191,7 +191,7 @@ cohorts and is less precisely estimated.
 
 
 Summarizing the overall effect
-==============================
+------------------------------
 
 For policy discussions, you often need a single number that summarizes the
 average treatment effect. The ``"simple"`` aggregation provides this by
@@ -235,7 +235,7 @@ examine the dynamic effects before reporting only the overall ATT.
 
 
 Examining heterogeneity by cohort
-=================================
+---------------------------------
 
 Different cohorts may experience different effects due to variation in
 local economic conditions, policy implementation, or the composition of
@@ -291,7 +291,7 @@ to provide a more complete picture.
 
 
 Plotting results
-================
+----------------
 
 Visualizations make it easier to communicate findings and spot patterns.
 The group-time plot shows all the underlying estimates organized by cohort.
@@ -322,7 +322,7 @@ in a causal interpretation.
 
 
 Next steps
-==========
+----------
 
 For details on estimation options such as covariates, control groups,
 bootstrap inference, and clustering, see the :ref:`quickstart <quickstart>` or

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -1,0 +1,20 @@
+.. _user-guide:
+
+####################
+ModernDiD User Guide
+####################
+
+This guide provides an overview of ModernDiD and explains the important
+features; details are found in :ref:`api`.
+
+.. toctree::
+   :caption: Getting started
+   :maxdepth: 2
+
+   user_guide
+
+.. toctree::
+   :caption: Examples
+   :maxdepth: 2
+
+   example_staggered_did

--- a/docs/source/user_guide/user_guide.rst
+++ b/docs/source/user_guide/user_guide.rst
@@ -19,7 +19,7 @@ For theoretical details on each estimator, see the :ref:`Background <background>
 
 
 Core Arguments
-==============
+--------------
 
 Every estimator requires four variables that identify the panel structure.
 
@@ -45,7 +45,7 @@ all estimators. Once you learn one, the others follow the same patterns.
 
 
 Basic Usage
-===========
+-----------
 
 We will focus on the :func:`~moderndid.did.att_gt` function, which estimates group-time average
 treatment effects for staggered adoption designs. Other estimators follow the same pattern with
@@ -82,7 +82,7 @@ into interpretable summaries.
 
 
 Estimation Options
-==================
+------------------
 
 The ``att_gt`` function provides several options for customizing the
 estimation procedure. The defaults reflect best practices, but you may
@@ -90,7 +90,7 @@ want to adjust them based on your data and research design.
 
 
 Estimation Methods
-------------------
+^^^^^^^^^^^^^^^^^^
 
 The ``est_method`` parameter controls how group-time effects are
 estimated. The default is ``"dr"`` for doubly robust, but you can also
@@ -120,7 +120,7 @@ model is correctly specified.
 
 
 Covariates
-----------
+^^^^^^^^^^
 
 When treated and comparison groups differ on observable characteristics,
 include covariates using the ``xformla`` parameter. This strengthens the
@@ -142,7 +142,7 @@ measured before treatment to avoid conditioning on post-treatment variables.
 
 
 Control Group
--------------
+^^^^^^^^^^^^^
 
 By default, ``att_gt`` uses never-treated units as the comparison group.
 You can instead use not-yet-treated units, which includes units that will
@@ -165,7 +165,7 @@ unrelated to potential outcomes.
 
 
 Bootstrap Inference
--------------------
+^^^^^^^^^^^^^^^^^^^
 
 By default, ``att_gt`` uses the multiplier bootstrap to compute standard
 errors and simultaneous confidence bands.
@@ -192,7 +192,7 @@ intervals instead of simultaneous bands.
 
 
 Clustering
-----------
+^^^^^^^^^^
 
 Standard errors can be clustered at one or two levels using the
 ``clustervars`` parameter. Clustering requires using the bootstrap.
@@ -214,7 +214,7 @@ unit identifier (``idname``).
 
 
 Anticipation
-------------
+^^^^^^^^^^^^
 
 If units can anticipate treatment before it actually occurs, account for
 this using the ``anticipation`` parameter. This shifts the base period
@@ -237,7 +237,7 @@ by anticipation of the upcoming treatment.
 
 
 Base Period
------------
+^^^^^^^^^^^
 
 The ``base_period`` parameter controls which pre-treatment period is used
 as the comparison. The default ``"varying"`` uses the period immediately
@@ -257,7 +257,7 @@ estimates to be relative to the same reference point.
 
 
 Panel Data Options
-------------------
+^^^^^^^^^^^^^^^^^^
 
 By default, ``att_gt`` expects a balanced panel where all units are
 observed in all time periods. If your panel is unbalanced, set
@@ -279,7 +279,7 @@ and omit the ``idname`` parameter.
 
 
 Sampling Weights
-----------------
+^^^^^^^^^^^^^^^^
 
 If your data has sampling weights, specify them using ``weightsname``.
 
@@ -296,7 +296,7 @@ If your data has sampling weights, specify them using ``weightsname``.
 
 
 Visualization
-=============
+-------------
 
 ModernDiD provides built-in plotting functions using plotnine.
 
@@ -310,7 +310,7 @@ ModernDiD provides built-in plotting functions using plotnine.
 
 
 Other Estimators
-================
+----------------
 
 ModernDiD provides additional estimators for different research designs.
 All estimators share the same core API, so once you learn ``att_gt``, or another estimator,
@@ -318,7 +318,7 @@ the others follow the same pattern with estimator-specific parameters.
 
 
 Continuous Treatment DiD
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :func:`~moderndid.didcont.cont_did` function handles settings with
 treatment intensity rather than binary treatment. We can compare the function
@@ -384,7 +384,7 @@ identically.
 
 
 Triple Difference-in-Differences
---------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :func:`~moderndid.didtriple.ddd` function leverages an additional
 dimension of variation such as eligibility status. The API follows
@@ -410,7 +410,7 @@ arguments work the same as ``att_gt``.
 
 
 Sensitivity Analysis
---------------------
+^^^^^^^^^^^^^^^^^^^^
 
 The :mod:`~moderndid.didhonest` module assesses robustness to parallel
 trends violations. It takes results from ``att_gt``, or external event study results,
@@ -435,11 +435,3 @@ parallel trends violation.
     sensitivity = honest_did(event_study, event_time=0, sensitivity_type="smoothness")
 
 See the examples for detailed usage of each estimator.
-
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   self
-   example_staggered_did

--- a/moderndid/didhonest/fixed_length_ci.py
+++ b/moderndid/didhonest/fixed_length_ci.py
@@ -3,8 +3,9 @@
 from typing import NamedTuple
 
 import cvxpy as cp
-import numpy as np
 from scipy import stats
+
+import numpy as np
 
 from .utils import basis_vector, validate_conformable
 
@@ -93,20 +94,6 @@ def compute_flci(
         - optimal_half_length: Half-length of the confidence interval
         - smoothness_bound: Smoothness parameter :math:`M` used
         - status: Optimization status
-
-    Warnings
-    --------
-    FLCIs are recommended primarily for :math:`\Delta^{SD}(M)` where they have
-    guaranteed consistency and near-optimal finite-sample properties. For other
-    restriction sets, consider using conditional or hybrid confidence sets instead.
-
-    During the optimization process, you may encounter a warning from CVXPY about
-    "Solution may be inaccurate" when the solver reaches numerical precision limits.
-    This typically occurs during the binary search for optimal parameters when the
-    variance constraint becomes very tight (h values around 0.009 or smaller).
-    Despite this warning, the returned solution is still valid and usable. The
-    warning simply indicates that the solver terminated with status "optimal_inaccurate"
-    rather than "optimal" due to numerical precision constraints.
 
     Notes
     -----


### PR DESCRIPTION
This adds comprehensive documentation overhaul following NumPy's doc style. 

- Added detailed release notes for all versions (0.0.1, 0.0.2, 0.0.3) with linked commits and PRs, plus an unreleased section tracking changes since the last release. 
- Simplified the CSS to match NumPy's minimal approach. 
- Fixed RST heading hierarchy in user guide files so sidebar navigation properly displays subsections. 
- Restructured the main index page with grid cards and quick links. 
- Added index files for user_guide, api, background, and dev sections. 
- Updated `conf.py` to enable expanded sidebar navigation.