### PR TITLE
TEST: fix Dask test suite and update CI

### DIFF
--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -31,3 +31,29 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: Python ${{ matrix.python-version }} (full)
           fail_ci_if_error: false
+
+  test-dask:
+    name: Dask tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Run Dask test suite with coverage
+        run: tox -e dask-coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: Dask Python ${{ matrix.python-version }} (full)
+          fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,32 @@ jobs:
           name: Python ${{ matrix.python-version }}
           fail_ci_if_error: false
 
+  dask:
+    name: Dask tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Run Dask test suite with coverage
+        run: tox -e dask-coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: Dask Python ${{ matrix.python-version }}
+          fail_ci_if_error: false
+
   coverage:
     name: Full coverage (Python 3.12)
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ test = [
     "pytest",
     "pytest-benchmark",
     "pytest-cov",
+    "pytest-timeout",
     "pyfixest>=0.30.2",
 ]
 doc = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     check
     docs
-    {core,full}{,-coverage}
+    {core,full,dask}{,-coverage}
     validation
 isolated_build = True
 isolated_build_env = build
@@ -21,7 +21,7 @@ TEST_SUITE =
 
 [testenv]
 basepython =
-    {core,full,validation,check,docs,cleandocs,viewdocs}: python3
+    {core,full,dask,validation,check,docs,cleandocs,viewdocs}: python3
 setenv =
     PYTHONUNBUFFERED = yes
     PYTEST_EXTRA_ARGS = -s
@@ -66,6 +66,22 @@ extras =
     all
 commands =
     pytest --ignore=tests/dask --cov --cov-report xml --cov-report term {posargs:-vv}
+
+[testenv:dask]
+description = Run Dask distributed test suite
+extras =
+    test
+    all
+commands =
+    pytest tests/dask --timeout=120 {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+
+[testenv:dask-coverage]
+description = Run Dask distributed test suite with coverage
+extras =
+    test
+    all
+commands =
+    pytest tests/dask --timeout=120 --cov --cov-report xml --cov-report term {posargs:-vv}
 
 [testenv:validation]
 description = Run R validation tests only (requires R with did, DRDID, contdid, HonestDiD, triplediff packages)


### PR DESCRIPTION
Dask tests have been excluded from CI because Python 3.11 was hanging indefinitely during distributed client operations, likely due to asyncio event loop differences in 3.11. This dropped package coverage from ~85% to ~71% since the entire `moderndid/dask/` module went untested.

So this adds dedicated `dask` and `dask-coverage` tox environments that run only the Dask test suite, and introduces separate CI jobs in both `test.yml` and `test-full.yml` that execute these tests on Python 3.12 and 3.13 only, skipping 3.11 where the hang occurs. Each test gets a 120-second timeout via `pytest-timeout` as a safety net against future hangs.
