### PR TITLE
CI: stop ignoring distributed tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ extras =
     test
     all
 commands =
-    pytest -m "not slow" --ignore=tests/dask --ignore=tests/spark --ignore=tests/distributed {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+    pytest -m "not slow" --ignore=tests/dask --ignore=tests/spark {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 
 [testenv:core-coverage]
 description = Run core test suite with coverage
@@ -49,7 +49,7 @@ extras =
     test
     all
 commands =
-    pytest -m "not slow" --ignore=tests/dask --ignore=tests/spark --ignore=tests/distributed --cov --cov-report xml --cov-report term {posargs:-vv}
+    pytest -m "not slow" --ignore=tests/dask --ignore=tests/spark --cov --cov-report xml --cov-report term {posargs:-vv}
 
 [testenv:full]
 description = Run full test suite (all tests including slow ones)
@@ -57,7 +57,7 @@ extras =
     test
     all
 commands =
-    pytest --ignore=tests/dask --ignore=tests/spark --ignore=tests/distributed {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+    pytest --ignore=tests/dask --ignore=tests/spark {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 
 [testenv:full-coverage]
 description = Run full test suite with coverage
@@ -65,7 +65,7 @@ extras =
     test
     all
 commands =
-    pytest --ignore=tests/dask --ignore=tests/spark --ignore=tests/distributed --cov --cov-report xml --cov-report term {posargs:-vv}
+    pytest --ignore=tests/dask --ignore=tests/spark --cov --cov-report xml --cov-report term {posargs:-vv}
 
 [testenv:dask]
 description = Run Dask distributed test suite


### PR DESCRIPTION
This is causing the coverage to look worse than it actually is. Tests for distributed do not use any local dask or spark connections so should be fine to run in CI.